### PR TITLE
Recipe App: Create models `Recipe` and `RecipeFood`

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,0 +1,4 @@
+class Recipe < ApplicationRecord
+  belongs_to :user
+  has_many :recipe_foods
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,4 +1,6 @@
 class Recipe < ApplicationRecord
   belongs_to :user
   has_many :recipe_foods
+  validates :name, presence: { message: 'Please enter a name' }, length: { minimum: 2 }
+  validates :description, length: { maximum: 1000, message: 'The description is too long' }
 end

--- a/app/models/recipe_food.rb
+++ b/app/models/recipe_food.rb
@@ -1,0 +1,4 @@
+class RecipeFood < ApplicationRecord
+  belongs_to :recipe
+  has_many :foods
+end

--- a/app/models/recipe_food.rb
+++ b/app/models/recipe_food.rb
@@ -1,4 +1,5 @@
 class RecipeFood < ApplicationRecord
   belongs_to :recipe
   has_many :foods
+  validates :quantity, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/db/migrate/20230314121110_create_recipes.rb
+++ b/db/migrate/20230314121110_create_recipes.rb
@@ -1,0 +1,14 @@
+class CreateRecipes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :recipes do |t|
+      t.string :name
+      t.string :preparation_time
+      t.string :cooking_time
+      t.text :description
+      t.boolean :public
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230314121956_create_recipe_foods.rb
+++ b/db/migrate/20230314121956_create_recipe_foods.rb
@@ -1,0 +1,12 @@
+class CreateRecipeFoods < ActiveRecord::Migration[7.0]
+  def change
+    create_table :recipe_foods do |t|
+      t.integer :quantity
+      t.integer :recipe_id
+      t.integer :food_id
+      t.references :recipe, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/models/recipe_food_spec.rb
+++ b/spec/models/recipe_food_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RecipeFood, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Recipe, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Summary
- In this feature, I added 2 models `Recipe` and `RecipeFood` with their attribute validation.

## Changes log
 - [x] Generated `Recipe` model
 - [x] Generated `RecipeFood` model
 - [x] Added connections between the two models (`has_many` and `belongs_to`) according to the [diagram](
https://user-images.githubusercontent.com/50754458/225001485-c6059430-3562-4f0d-ad63-f2a1a5a733dd.png
)

## Acceptance criteria

- [x] Models should correspond to the [ERD](https://user-images.githubusercontent.com/50754458/225001485-c6059430-3562-4f0d-ad63-f2a1a5a733dd.png) diagram
- [x] The connection between 2 models should be correct